### PR TITLE
fix: disable code signing for macOS ARM64 builds

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,6 +21,7 @@ nsis:
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   notarize: false
+  identity: null
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:


### PR DESCRIPTION
## Summary
- Fixes macOS ARM64 build launch issues by disabling code signing
- Resolves dyld library loading errors caused by Team ID mismatches