### PR TITLE
Fix deadlock causing app hang during Master Password unlock (Windows 11)

### DIFF
--- a/src-tauri/src/services/sync/mod.rs
+++ b/src-tauri/src/services/sync/mod.rs
@@ -69,17 +69,19 @@ impl SyncService {
             local_guard.get_all_external_databases().await?
         }; // Drop locks
 
-        let db_service = self.database_service.lock().await;
-        let local_db = db_service.get_local_database();
-        let sync_settings = {
-            let guard = local_db.read().await;
-            guard.get_global_sync_settings().await?
-        };
+        let auto_sync_enabled = {
+            let db_service = self.database_service.lock().await;
+            let local_db = db_service.get_local_database();
+            let sync_settings = {
+                let guard = local_db.read().await;
+                guard.get_global_sync_settings().await?
+            };
 
-        let auto_sync_enabled = sync_settings
-            .as_ref()
-            .map(|s| s.auto_sync_enabled)
-            .unwrap_or(false);
+            sync_settings
+                .as_ref()
+                .map(|s| s.auto_sync_enabled)
+                .unwrap_or(false)
+        };
 
         if auto_sync_enabled {
             for config in configs {


### PR DESCRIPTION
## Description
This PR resolves a critical deadlock that occurs during the application startup and Master Password unlock phase. The issue was observed to cause the application to hang indefinitely, particularly on Windows 11.

### The Bug
In `SyncService::initialize`, a lock on `database_service` was held while iterating through external database configurations and calling [connect()](file:///d:/Code-Tool/Vibe/source-kerminal/src-tauri/src/services/sync/manager.rs#27-80).
The [connect()](file:///d:/Code-Tool/Vibe/source-kerminal/src-tauri/src/services/sync/manager.rs#27-80) method in [SyncManager](file:///d:/Code-Tool/Vibe/source-kerminal/src-tauri/src/services/sync/manager.rs#14-18) subsequently attempts to acquire the same `database_service` lock to update sync settings.
Since Tokio's `Mutex` is not reentrant, this caused a deadlock, blocking the entire auth thread.

### The Fix
I refactored `SyncService::initialize` in [src-tauri/src/services/sync/mod.rs](file:///d:/Code-Tool/Vibe/source-kerminal/src-tauri/src/services/sync/mod.rs) to strictly limit the scope of the `database_service` lock. The lock is now acquired to read the configuration and then strictly dropped *before* entering the connection loop.

## Changes
- **Modified**: [src-tauri/src/services/sync/mod.rs](file:///d:/Code-Tool/Vibe/source-kerminal/src-tauri/src/services/sync/mod.rs)
  - Scoped `database_service` locking block to ensure it is released before calling `self.sync_manager.connect()`.

## Verification
- Verified that the "Unlock Master Password" flow no longer hangs.
- Verified that sync settings are still correctly read and auto-connect logic still executes.
