### PR TITLE
fix: add configurable WebGL terminal renderer setting

### DIFF
--- a/src/components/settings/ThemeSelectorModal.vue
+++ b/src/components/settings/ThemeSelectorModal.vue
@@ -30,6 +30,28 @@
       </Button>
     </div>
 
+    <Card
+      no-padding
+      :custom-class="'mb-4 p-4 border-gray-700/70 bg-gray-800/40'"
+    >
+      <div class="flex items-start gap-3">
+        <Checkbox
+          id="use-webgl-renderer"
+          v-model="useWebGLRenderer"
+          class="mt-0.5 mb-0!"
+        />
+        <div class="min-w-0">
+          <p class="text-sm font-medium text-gray-200">
+            Use WebGL terminal renderer (restart required)
+          </p>
+          <p class="text-xs text-gray-500 mt-1">
+            May improve performance, but can cause input lag or issues on some
+            Linux systems.
+          </p>
+        </div>
+      </div>
+    </Card>
+
     <!-- Custom Themes Section -->
     <div v-if="settingsStore.customThemes.length > 0" class="space-y-2 mb-6">
       <div class="flex items-center gap-2 px-2 py-1.5">
@@ -214,6 +236,7 @@ import { Palette, Check, Plus, Edit2, Trash2, Type } from "lucide-vue-next";
 import Modal from "../ui/Modal.vue";
 import Button from "../ui/Button.vue";
 import Card from "../ui/Card.vue";
+import Checkbox from "../ui/Checkbox.vue";
 import { useSettingsStore } from "../../stores/settings";
 import { getTerminalTheme } from "../../utils/terminalTheme";
 import { useOverlay } from "../../composables/useOverlay";
@@ -229,6 +252,13 @@ const customThemesList = computed(() => {
 
 const builtInThemesList = computed(() => {
   return settingsStore.builtInThemes;
+});
+
+const useWebGLRenderer = computed({
+  get: () => settingsStore.useWebGLRenderer,
+  set: (enabled: boolean) => {
+    void settingsStore.setUseWebGLRenderer(enabled);
+  },
 });
 
 const selectTheme = async (theme: string) => {

--- a/src/components/ui/Terminal.vue
+++ b/src/components/ui/Terminal.vue
@@ -173,6 +173,7 @@ import { writeText, readText } from "@tauri-apps/plugin-clipboard-manager";
 import Button from "./Button.vue";
 import HistorySearchModal from "../history/HistorySearchModal.vue";
 import { getTerminalTheme } from "../../utils/terminalTheme";
+import { loadWebGLRenderer } from "../../utils/terminalRenderer";
 import { useSettingsStore } from "../../stores/settings";
 import { useOverlayStore } from "../../stores/overlay";
 import type { PanelLayout, Tab } from "../../types/panel";
@@ -184,7 +185,6 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { ImageAddon } from "@xterm/addon-image";
 
 interface TerminalProps {
@@ -632,8 +632,7 @@ onMounted(async () => {
     theme: theme,
   });
 
-  const webglAddon = new WebglAddon();
-  term.loadAddon(webglAddon);
+  await loadWebGLRenderer(term, settingsStore.useWebGLRenderer);
 
   fitAddon = new FitAddon();
   term.loadAddon(fitAddon);

--- a/src/components/ui/TerminalManager.vue
+++ b/src/components/ui/TerminalManager.vue
@@ -22,12 +22,12 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { ImageAddon } from "@xterm/addon-image";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { writeText, readText } from "@tauri-apps/plugin-clipboard-manager";
 
 import { getTerminalTheme } from "../../utils/terminalTheme";
+import { loadWebGLRenderer } from "../../utils/terminalRenderer";
 import { useSettingsStore } from "../../stores/settings";
 
 interface TerminalManagerProps {
@@ -82,8 +82,7 @@ const createTerminalInstance = async (
     theme: theme,
   });
 
-  const webglAddon = new WebglAddon();
-  term.loadAddon(webglAddon);
+  await loadWebGLRenderer(term, settingsStore.useWebGLRenderer);
 
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -26,6 +26,7 @@ import { getSystemInfo as getSystemInfoService } from "../services/dashboard";
 import type { TerminalTheme } from "../utils/terminalTheme";
 import { handleError, type ErrorContext } from "../utils/errorHandler";
 import { message } from "../utils/message";
+import { getDefaultUseWebGLRenderer } from "../utils/terminalRenderer";
 
 export interface CustomTheme {
   id: string;
@@ -75,6 +76,7 @@ export const useSettingsStore = defineStore("settings", () => {
   // Terminal font preferences
   const fontFamily = ref<string>("FiraCode Nerd Font");
   const fontSize = ref<number>(13);
+  const useWebGLRenderer = ref<boolean>(getDefaultUseWebGLRenderer());
 
   // Available built-in themes
   const builtInThemes = getAvailableThemes();
@@ -117,6 +119,12 @@ export const useSettingsStore = defineStore("settings", () => {
       if (savedFontSize) {
         fontSize.value = savedFontSize;
       }
+
+      const savedUseWebGLRenderer =
+        await storeInstance.get<boolean>("use-webgl-renderer");
+      if (typeof savedUseWebGLRenderer === "boolean") {
+        useWebGLRenderer.value = savedUseWebGLRenderer;
+      }
     } catch (error) {
       const errorMessage = handleError(error, context);
       message.error(errorMessage);
@@ -138,6 +146,7 @@ export const useSettingsStore = defineStore("settings", () => {
       await storeInstance.set("terminal-theme", terminalTheme.value);
       await storeInstance.set("font-family", fontFamily.value);
       await storeInstance.set("font-size", fontSize.value);
+      await storeInstance.set("use-webgl-renderer", useWebGLRenderer.value);
       await storeInstance.save();
     } catch (error) {
       const errorMessage = handleError(error, context);
@@ -223,6 +232,11 @@ export const useSettingsStore = defineStore("settings", () => {
     await saveSettings();
   };
 
+  const setUseWebGLRenderer = async (enabled: boolean) => {
+    useWebGLRenderer.value = enabled;
+    await saveSettings();
+  };
+
   const upsertCustomTheme = (theme: CustomTheme) => {
     if (!theme?.id) return;
     const i = customThemes.value.findIndex((t) => t.id === theme.id);
@@ -292,12 +306,10 @@ export const useSettingsStore = defineStore("settings", () => {
    * @returns Array of system font names
    */
 
-
   /**
    * Get system info with error handling
    * @returns System information
    */
-
 
   // Initialize settings on store creation
   loadSettings();
@@ -309,10 +321,12 @@ export const useSettingsStore = defineStore("settings", () => {
     builtInThemes,
     fontFamily,
     fontSize,
+    useWebGLRenderer,
     isLoading,
     setTerminalTheme,
     setFontFamily,
     setFontSize,
+    setUseWebGLRenderer,
     loadSettings,
     createCustomTheme,
     updateCustomTheme,

--- a/src/utils/terminalRenderer.ts
+++ b/src/utils/terminalRenderer.ts
@@ -1,0 +1,35 @@
+import type { Terminal } from "@xterm/xterm";
+
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
+const getPlatformHint = (): string => {
+  if (typeof navigator === "undefined") return "";
+
+  const nav = navigator as NavigatorWithUAData;
+
+  return nav.userAgentData?.platform || navigator.platform || navigator.userAgent || "";
+};
+
+export const isLinuxPlatform = (): boolean =>
+  getPlatformHint().toLowerCase().includes("linux");
+
+export const getDefaultUseWebGLRenderer = (): boolean => !isLinuxPlatform();
+
+export const loadWebGLRenderer = async (
+  term: Terminal,
+  enabled: boolean,
+): Promise<void> => {
+  if (!enabled) return;
+
+  try {
+    const { WebglAddon } = await import("@xterm/addon-webgl");
+    const webglAddon = new WebglAddon();
+    term.loadAddon(webglAddon);
+  } catch (error) {
+    console.warn("WebGL renderer failed, falling back", error);
+  }
+};


### PR DESCRIPTION
This PR adds a user-configurable setting to control xterm.js WebGL renderer usage instead of hardcoding it.

It fixes severe input latency on some Linux systems by allowing WebGL to be disabled safely.

## Problem

On Linux (especially Wayland sessions), enabling `@xterm/addon-webgl` can cause heavy input lag.
In my case (Ubuntu KDE + Wayland), keypress latency was around 1–1.6s per key.

Disabling WebGL rendering removed the lag completely.

This keeps WebGL available for users who want it, while preventing Linux users from getting degraded input performance by default.

## Related issue

Closes #23  
https://github.com/klpod221/kerminal/issues/23
